### PR TITLE
Fix tests and add support for Python3

### DIFF
--- a/SegmentMesher/SegmentMesher.py
+++ b/SegmentMesher/SegmentMesher.py
@@ -686,7 +686,7 @@ class SegmentMesherTest(ScriptedLoadableModuleTest):
     outputModelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
     outputModelNode.CreateDefaultDisplayNodes()
 
-    logic = TetGenLogic()
+    logic = SegmentMesherLogic()
     logic.createMeshFromPolyDataTetGen(inputModelNode.GetPolyData(), outputModelNode)
 
     self.assertTrue(outputModelNode.GetMesh().GetNumberOfPoints()>0)

--- a/SegmentMesher/SegmentMesher.py
+++ b/SegmentMesher/SegmentMesher.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer
@@ -275,14 +276,14 @@ class SegmentMesherWidget(ScriptedLoadableModuleWidget):
       self.logic.logStandardOutput = self.showDetailedLogDuringExecutionCheckBox.checked
 
       method = self.methodSelectorComboBox.itemData(self.methodSelectorComboBox.currentIndex)
-      print method
+      print(method)
       if method == METHOD_CLEAVER:
         self.logic.createMeshFromSegmentationCleaver(self.inputModelSelector.currentNode(), self.outputModelSelector.currentNode(), self.cleaverAdditionalParametersWidget.text)
       else:
         self.logic.createMeshFromSegmentationTetGen(self.inputModelSelector.currentNode(), self.outputModelSelector.currentNode(), self.tetGenAdditionalParametersWidget.text)
 
     except Exception as e:
-      print e
+      print(e)
       self.addLog("Error: {0}".format(e.message))
       import traceback
       traceback.print_exc()


### PR DESCRIPTION
This fixes a [failing test](http://slicer.cdash.org/testDetails.php?test=9640493&build=1605904) for Slicer 4.10 and adds fixes for Python3 support.