### PR TITLE
COMP: Update tetgen & cleaver external project to fix git source checkout

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -1,14 +1,3 @@
-
-#-----------------------------------------------------------------------------
-# Git protocol option
-#-----------------------------------------------------------------------------
-option(Slicer_USE_GIT_PROTOCOL "If behind a firewall turn this off to use http instead." ON)
-
-set(git_protocol "git")
-if(NOT Slicer_USE_GIT_PROTOCOL)
-  set(git_protocol "http")
-endif()
-
 #-----------------------------------------------------------------------------
 # Enable and setup External project global properties
 #-----------------------------------------------------------------------------

--- a/SuperBuild/External_cleaver.cmake
+++ b/SuperBuild/External_cleaver.cmake
@@ -22,10 +22,6 @@ endif()
 
 if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
-  if(NOT DEFINED git_protocol)
-    set(git_protocol "git")
-  endif()
-
   set(${proj}_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
   set(${proj}_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
@@ -36,7 +32,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     SOURCE_SUBDIR src # requires CMake 3.7 or later
     BINARY_DIR ${proj}-build
     INSTALL_DIR ${${proj}_INSTALL_DIR}
-    GIT_REPOSITORY "${git_protocol}://github.com/SCIInstitute/Cleaver2.git"
+    GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/SCIInstitute/Cleaver2.git"
     GIT_TAG "4b37dab103ebfc86d26e282b33cbca724ef5fde5"
     #--Patch step-------------  
     #PATCH_COMMAND ${CMAKE_COMMAND} -Delastix_SRC_DIR=${CMAKE_BINARY_DIR}/${proj}

--- a/SuperBuild/External_tetgen.cmake
+++ b/SuperBuild/External_tetgen.cmake
@@ -17,10 +17,6 @@ endif()
 
 if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
-  if(NOT DEFINED git_protocol)
-    set(git_protocol "git")
-  endif()
-
   set(${proj}_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
   set(${proj}_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
@@ -31,7 +27,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     #SOURCE_SUBDIR src # requires CMake 3.7 or later
     BINARY_DIR ${proj}-build
     INSTALL_DIR ${${proj}_INSTALL_DIR}
-    GIT_REPOSITORY "${git_protocol}://github.com/lassoan/tetgen.git"
+    GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/lassoan/tetgen.git"
     #GIT_TAG "ef057ff89233822b26b04b31c3c043af57d5deff"
     #--Patch step-------------
     #PATCH_COMMAND ${CMAKE_COMMAND} -Delastix_SRC_DIR=${CMAKE_BINARY_DIR}/${proj}


### PR DESCRIPTION
This commit updates the external project to use the variable EP_GIT_PROTOCOL
introduced in Slicer/Slicer@f1fdf637df (ENH: Simplify buildsystem using EP_GIT_PROTOCOL
provided by ExternalProjectDependency)

GitHub has disabled the unauthenticated git protocol by default and this
commit ensures that extension will inherits the protocol selected in
the Slicer build.

References:
* https://github.blog/2021-09-01-improving-git-protocol-security-github
* https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide#Slicer_4.9:_Support_EP_GIT_PROTOCOL_and_use_of_ExternalProject_SetIfNotDefined_for_setting_GIT_REPOSITORY.2C_GIT_TAG_and_alike

Co-authored-by: Shreeraj Jadhav <shreeraj.jadhav@kitware.com>